### PR TITLE
Improve mobile responsiveness

### DIFF
--- a/assets/site.js
+++ b/assets/site.js
@@ -26,15 +26,34 @@
 (function(){
   const header = document.querySelector('.header');
   if(!header) return;
+  const root = document.documentElement;
+  const setHeight = ()=>{
+    const rect = header.getBoundingClientRect();
+    root.style.setProperty('--header-height', Math.round(rect.height) + 'px');
+  };
+  setHeight();
+  if('ResizeObserver' in window){
+    const observer = new ResizeObserver(setHeight);
+    observer.observe(header);
+  } else {
+    window.addEventListener('resize', setHeight, {passive:true});
+  }
   let last = window.scrollY || 0;
-  window.addEventListener('scroll', ()=>{
+  let condensed = header.classList.contains('is-condensed');
+  const onScroll = ()=>{
     const current = window.scrollY || 0;
-    if(current > 40) header.classList.add('is-condensed');
-    else header.classList.remove('is-condensed');
+    const shouldCondense = current > 40;
+    header.classList.toggle('is-condensed', shouldCondense);
+    if(shouldCondense !== condensed){
+      condensed = shouldCondense;
+      setHeight();
+    }
     const hidden = current > last && current > 120;
     header.classList.toggle('is-hidden', hidden);
     last = current;
-  }, {passive:true});
+  };
+  window.addEventListener('scroll', onScroll, {passive:true});
+  onScroll();
 })();
 
 // Navigation toggle (mobile)

--- a/assets/style.css
+++ b/assets/style.css
@@ -19,6 +19,7 @@
   --shadow-lg:0 32px 80px rgba(3,7,23,0.55);
   --font-sans:'Manrope','Inter','Segoe UI',system-ui,-apple-system,BlinkMacSystemFont,sans-serif;
   --font-display:'Space Grotesk','Manrope','Inter',system-ui,sans-serif;
+  --header-height:92px;
 }
 
 *{box-sizing:border-box}
@@ -30,6 +31,7 @@ body{
   line-height:1.7;
   letter-spacing:0.01em;
   min-height:100vh;
+  overflow-x:hidden;
 }
 body::before{
   content:"";
@@ -361,34 +363,142 @@ main.spotlight::before{inset:-220px -180px;opacity:0.5}
   .nav-toggle{display:flex}
   .nav{
     position:fixed;
-    inset:90px 24px auto 24px;
+    top:calc(var(--header-height, 92px) + 12px + env(safe-area-inset-top, 0px));
+    left:calc(env(safe-area-inset-left, 0px) + 20px);
+    right:calc(env(safe-area-inset-right, 0px) + 20px);
     border-radius:24px;
-    padding:28px;
+    padding:24px;
     background:rgba(5,10,23,0.96);
     border:1px solid rgba(255,255,255,0.08);
     box-shadow:0 30px 70px rgba(3,6,16,0.7);
     flex-direction:column;
     align-items:flex-start;
     gap:12px;
+    max-width:420px;
+    margin:0 auto;
+    max-height:calc(100vh - (var(--header-height, 92px) + 36px + env(safe-area-inset-top, 0px) + env(safe-area-inset-bottom, 0px)));
+    overflow:auto;
+    overscroll-behavior:contain;
     transform:translateY(-20px);
     opacity:0;
     pointer-events:none;
     transition:opacity .25s ease, transform .25s ease;
+    padding-bottom:calc(24px + env(safe-area-inset-bottom, 0px));
   }
+  .nav a{width:100%;font-size:16px}
   .nav.is-open{opacity:1;transform:translateY(0);pointer-events:auto}
   .footer .footer-grid{grid-template-columns:1fr}
 }
 @media (max-width:720px){
   .container{width:min(100%,calc(100% - 32px))}
+  .header-row{gap:22px}
   .hero{padding:110px 0 80px}
+  .hero::after{inset:26px -60px -44px -60px}
   .hero h1{font-size:clamp(38px,9vw,52px)}
+  .hero .lead{font-size:17px}
   .hero-metrics{gap:24px}
   .section{padding:90px 0}
   .section-title{font-size:30px}
+  .section-lead{font-size:16px}
+  .grid{gap:22px}
+  .panel,.card,.timeline-step,.hero-panel{padding:28px}
   .cta{padding:48px 28px}
+  .cta p{font-size:16px}
+  .spotlight::before{inset:-150px -120px}
+  main.spotlight::before{inset:-190px -140px}
+}
+@media (max-width:600px){
+  .header-row{gap:18px}
+  .brand .logo{width:50px;height:50px}
+  .brand .wordmark{font-size:24px}
+  .hero{padding:104px 0 76px}
+  .hero .lead{font-size:16px}
+  .hero-metrics{gap:20px}
+  .hero-metrics li{min-width:150px}
+  .section{padding:84px 0}
+  .grid{gap:20px}
+  .panel,.card,.timeline-step,.hero-panel{padding:26px}
+  .cta{padding:44px 26px}
 }
 @media (max-width:520px){
-  .hero-panel{padding:28px}
-  .card{padding:28px}
-  .timeline-step{padding:24px}
+  .container{width:min(100%,calc(100% - 28px))}
+  .header-row{gap:16px}
+  .nav{left:calc(env(safe-area-inset-left, 0px) + 16px);right:calc(env(safe-area-inset-right, 0px) + 16px);padding:22px}
+  .nav a{font-size:15px}
+  .nav-toggle{width:44px;height:44px}
+  .brand{gap:12px}
+  .brand .logo{width:46px;height:46px}
+  .brand .wordmark{font-size:22px;letter-spacing:0.06em}
+  .btn{padding:12px 16px;font-size:14px;border-radius:14px}
+  .hero{padding:100px 0 72px}
+  .hero::after{inset:20px -40px -36px -40px}
+  .hero h1{font-size:clamp(34px,10vw,48px)}
+  .hero .lead{font-size:16px}
+  .hero-cta{gap:10px}
+  .hero-cta .btn{width:100%}
+  .hero-metrics{gap:18px}
+  .hero-metrics li{min-width:140px}
+  .section{padding:80px 0}
+  .section-title{font-size:clamp(26px,8vw,30px)}
+  .section-lead{font-size:15px}
+  .grid{gap:20px}
+  .hero-panel,.card,.timeline-step,.panel{padding:24px;border-radius:22px}
+  .cta{padding:40px 24px;border-radius:30px}
+  .cta h2{font-size:clamp(26px,8vw,32px)}
+  .cta p{font-size:15px}
+  .spotlight::before{inset:-130px -100px}
+  main.spotlight::before{inset:-170px -120px}
+  .footer{padding:60px 0 40px}
+  .footer-title{font-size:24px}
+  .footer .footer-grid{gap:32px}
+  .footer .footer-meta{gap:18px;font-size:12px}
+  .quote{font-size:17px}
+}
+@media (max-width:420px){
+  .container{width:min(100%,calc(100% - 24px))}
+  .header-row{gap:14px}
+  .brand{gap:10px}
+  .brand .logo{width:44px;height:44px}
+  .brand .wordmark{font-size:20px}
+  .nav{left:calc(env(safe-area-inset-left, 0px) + 12px);right:calc(env(safe-area-inset-right, 0px) + 12px);padding:20px 18px}
+  .nav-toggle{width:42px;height:42px}
+  .nav a{font-size:15px;padding:12px 16px}
+  .hero{padding:92px 0 64px}
+  .hero::after{inset:16px -28px -30px -28px}
+  .hero h1{font-size:clamp(32px,10vw,44px)}
+  .hero .lead{font-size:15px}
+  .hero-cta{gap:8px;flex-direction:column;align-items:stretch}
+  .hero-cta .btn{width:100%}
+  .hero-metrics{gap:16px}
+  .hero-metrics li{min-width:0}
+  .section{padding:72px 0}
+  .section-title{font-size:clamp(24px,9vw,30px)}
+  .section-lead{font-size:15px}
+  .grid{gap:18px}
+  .hero-panel,.card,.timeline-step,.panel{padding:22px;border-radius:20px}
+  .cta{padding:32px 20px;border-radius:26px}
+  .cta h2{font-size:clamp(24px,9vw,30px)}
+  .cta p{font-size:15px}
+  .spotlight::before{inset:-120px -90px}
+  main.spotlight::before{inset:-150px -110px}
+  .footer{padding:56px 0 36px}
+  .footer .footer-grid{gap:28px}
+  .footer .footer-meta{flex-direction:column;align-items:flex-start;gap:14px}
+  .footer-title{font-size:22px}
+  .quote{font-size:16px}
+}
+@media (max-width:360px){
+  .container{width:min(100%,calc(100% - 20px))}
+  .brand .wordmark{font-size:18px;letter-spacing:0.05em}
+  .hero{padding:88px 0 60px}
+  .hero::after{inset:12px -20px -26px -20px}
+  .hero h1{font-size:clamp(30px,11vw,38px)}
+  .hero .lead{font-size:14px}
+  .hero-cta{gap:6px}
+  .btn{padding:10px 14px}
+  .nav{padding:18px}
+  .nav a{padding:10px 12px}
+  .section{padding:68px 0}
+  .cta{padding:28px 18px}
+  .footer{padding:52px 0 32px}
 }


### PR DESCRIPTION
## Summary
- refine the mobile navigation overlay with safe-area spacing, scroll limits, and full-width links
- add responsive breakpoints and spacing/typography adjustments for small viewports across sections
- update the header script to keep a CSS variable in sync with the current header height for layout math

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cf49da04808321992d83553a729d7f