### PR TITLE
Add safe area padding for mobile nav

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -446,7 +446,7 @@ main.spotlight::before{inset:-220px -180px;opacity:0.5}
 @media (max-width:520px){
   .container{width:min(100%,calc(100% - 28px))}
   .header-row{gap:16px}
-  .nav{left:calc(env(safe-area-inset-left, 0px) + 16px);right:calc(env(safe-area-inset-right, 0px) + 16px);padding:22px}
+  .nav{left:calc(env(safe-area-inset-left, 0px) + 16px);right:calc(env(safe-area-inset-right, 0px) + 16px);padding:22px;padding-bottom:calc(22px + env(safe-area-inset-bottom, 0px));}
   .nav a{font-size:15px}
   .nav-toggle{width:44px;height:44px}
   .brand{gap:12px}
@@ -483,7 +483,7 @@ main.spotlight::before{inset:-220px -180px;opacity:0.5}
   .brand{gap:10px}
   .brand .logo{width:44px;height:44px}
   .brand .wordmark{font-size:20px}
-  .nav{left:calc(env(safe-area-inset-left, 0px) + 12px);right:calc(env(safe-area-inset-right, 0px) + 12px);padding:20px 18px}
+  .nav{left:calc(env(safe-area-inset-left, 0px) + 12px);right:calc(env(safe-area-inset-right, 0px) + 12px);padding:20px 18px;padding-bottom:calc(20px + env(safe-area-inset-bottom, 0px));}
   .nav-toggle{width:42px;height:42px}
   .nav a{font-size:15px;padding:12px 16px}
   .hero{padding:92px 0 64px}
@@ -519,7 +519,7 @@ main.spotlight::before{inset:-220px -180px;opacity:0.5}
   .hero .lead{font-size:14px}
   .hero-cta{gap:6px}
   .btn{padding:10px 14px}
-  .nav{padding:18px}
+  .nav{padding:18px;padding-bottom:calc(18px + env(safe-area-inset-bottom, 0px));}
   .nav a{padding:10px 12px}
   .section{padding:68px 0}
   .cta{padding:28px 18px}


### PR DESCRIPTION
## Summary
- add safe-area bottom padding to the mobile navigation across 520px, 420px, and 360px breakpoints

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cf53b4c9048321b4cc36a4e9dabde0