### PR TITLE
Stabilize mobile navigation overlay and wire contact form backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# Copy to .env and adjust values before starting the contact server.
+# Omit SMTP_* variables to run in development mode (messages log to console).
+PORT=3000
+CONTACT_TO=axadmihn@axnmihn.com
+CONTACT_FROM=no-reply@axnmihn.com
+DOMAIN=axnmihn.com
+# SMTP_HOST=smtp.yourprovider.com
+# SMTP_PORT=587
+# SMTP_SECURE=false
+# SMTP_USER=apikey
+# SMTP_PASS=supersecret
+# CORS_ORIGIN=https://your-frontend-domain.example
+# STATIC_DIR=.

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+node_modules/
+.env
+
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*

--- a/assets/site.js
+++ b/assets/site.js
@@ -26,15 +26,34 @@
 (function(){
   const header = document.querySelector('.header');
   if(!header) return;
+  const root = document.documentElement;
+  const setHeight = ()=>{
+    const rect = header.getBoundingClientRect();
+    root.style.setProperty('--header-height', Math.round(rect.height) + 'px');
+  };
+  setHeight();
+  if('ResizeObserver' in window){
+    const observer = new ResizeObserver(setHeight);
+    observer.observe(header);
+  } else {
+    window.addEventListener('resize', setHeight, {passive:true});
+  }
   let last = window.scrollY || 0;
-  window.addEventListener('scroll', ()=>{
+  let condensed = header.classList.contains('is-condensed');
+  const onScroll = ()=>{
     const current = window.scrollY || 0;
-    if(current > 40) header.classList.add('is-condensed');
-    else header.classList.remove('is-condensed');
+    const shouldCondense = current > 40;
+    header.classList.toggle('is-condensed', shouldCondense);
+    if(shouldCondense !== condensed){
+      condensed = shouldCondense;
+      setHeight();
+    }
     const hidden = current > last && current > 120;
     header.classList.toggle('is-hidden', hidden);
     last = current;
-  }, {passive:true});
+  };
+  window.addEventListener('scroll', onScroll, {passive:true});
+  onScroll();
 })();
 
 // Navigation toggle (mobile)
@@ -42,12 +61,22 @@
   const nav = document.getElementById('site-nav');
   const toggle = document.querySelector('[data-nav-toggle]');
   if(!nav || !toggle) return;
+  const root = document.documentElement;
+  const applyScrollLock = ()=>{
+    const scrollBarWidth = Math.max(0, window.innerWidth - root.clientWidth);
+    document.body.style.setProperty('--scrollbar-compensation', scrollBarWidth ? scrollBarWidth + 'px' : '0px');
+  };
+  const releaseScrollLock = ()=>{
+    document.body.style.removeProperty('--scrollbar-compensation');
+  };
   const close = ()=>{
     nav.classList.remove('is-open');
     document.body.classList.remove('nav-open');
     toggle.setAttribute('aria-expanded', 'false');
+    releaseScrollLock();
   };
   const open = ()=>{
+    applyScrollLock();
     nav.classList.add('is-open');
     document.body.classList.add('nav-open');
     toggle.setAttribute('aria-expanded', 'true');
@@ -62,6 +91,8 @@
   window.addEventListener('resize', ()=>{
     if(window.innerWidth > 900){
       close();
+    } else if(nav.classList.contains('is-open')){
+      applyScrollLock();
     }
   }, {passive:true});
   document.addEventListener('keydown', (event)=>{
@@ -77,16 +108,89 @@
   if(el) el.textContent = 'BUILD_ID: ' + id;
 })();
 
-// Simple mailto form handler for static hosting
+// Contact form handler for API-backed submissions with graceful fallback
 (function(){
   const form = document.getElementById('contactForm');
   if(!form) return;
-  form.addEventListener('submit', (event)=>{
+  const endpoint = form.getAttribute('data-endpoint') || form.getAttribute('action') || '/api/contact';
+  const statusEl = document.getElementById('contactStatus');
+  const submitButton = form.querySelector('button[type="submit"]');
+  const directLink = form.querySelector('[data-direct-email]');
+  const defaultLabel = submitButton ? submitButton.textContent : '';
+  const setStatus = (message, state)=>{
+    if(!statusEl) return;
+    statusEl.textContent = message || '';
+    statusEl.classList.remove('form-status--pending', 'form-status--success', 'form-status--error', 'is-visible');
+    if(message){
+      statusEl.classList.add('is-visible');
+      if(state) statusEl.classList.add('form-status--' + state);
+    }
+  };
+  const setLoading = (isLoading)=>{
+    if(submitButton){
+      submitButton.disabled = isLoading;
+      submitButton.textContent = isLoading ? 'Sending…' : defaultLabel;
+    }
+    if(isLoading){
+      form.setAttribute('aria-busy', 'true');
+    } else {
+      form.removeAttribute('aria-busy');
+    }
+  };
+  const buildMailto = (name, email, message)=>{
+    const subject = encodeURIComponent('Hello from ' + (name || email || 'website visitor'));
+    const bodyParts = [];
+    if(message) bodyParts.push(message);
+    const reply = email ? 'reply-to: ' + email : '';
+    const signature = name ? 'sender: ' + name : '';
+    if(reply || signature) bodyParts.push('', [signature, reply].filter(Boolean).join('\n'));
+    return 'mailto:axadmihn@axnmihn.com?subject=' + subject + '&body=' + encodeURIComponent(bodyParts.join('\n'));
+  };
+  const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  form.addEventListener('submit', async (event)=>{
     event.preventDefault();
-    const email = (document.getElementById('yourEmail') || {}).value || '';
-    const msg = (document.getElementById('yourMessage') || {}).value || '';
-    const subject = encodeURIComponent('Hello from ' + (email || 'website visitor'));
-    const body = encodeURIComponent(msg + (email ? '\n\nreply-to: ' + email : ''));
-    window.location.href = 'mailto:axadmihn@axnmihn.com?subject=' + subject + '&body=' + body;
+    const name = ((document.getElementById('yourName') || {}).value || '').trim();
+    const email = ((document.getElementById('yourEmail') || {}).value || '').trim();
+    const message = ((document.getElementById('yourMessage') || {}).value || '').trim();
+    if(!name || !email || !message){
+      setStatus('Please complete every field before sending your message.', 'error');
+      return;
+    }
+    if(!emailPattern.test(email)){
+      setStatus('Enter a valid email so we can respond.', 'error');
+      return;
+    }
+    if(message.length < 10){
+      setStatus('Your message is a bit short—share at least 10 characters of context.', 'error');
+      return;
+    }
+    if(typeof window.fetch !== 'function'){
+      window.location.href = buildMailto(name, email, message);
+      return;
+    }
+    setLoading(true);
+    setStatus('Sending your message…', 'pending');
+    try {
+      const response = await fetch(endpoint, {
+        method:'POST',
+        headers:{'Content-Type':'application/json'},
+        body:JSON.stringify({name, email, message})
+      });
+      const contentType = response.headers.get('content-type') || '';
+      const payload = contentType.includes('application/json') ? await response.json() : {};
+      if(!response.ok){
+        const errorMessage = (payload && payload.error) || 'We could not deliver your message automatically.';
+        throw new Error(errorMessage);
+      }
+      setStatus("Thanks—your message is on its way. We'll respond within one business day.", 'success');
+      form.reset();
+      if(submitButton) submitButton.blur();
+    } catch (error){
+      console.error(error);
+      setStatus("We couldn't send your message automatically. Email us directly at axadmihn@axnmihn.com.", 'error');
+      if(directLink) directLink.focus();
+    } finally {
+      setLoading(false);
+    }
   });
 })();

--- a/assets/style.css
+++ b/assets/style.css
@@ -19,6 +19,7 @@
   --shadow-lg:0 32px 80px rgba(3,7,23,0.55);
   --font-sans:'Manrope','Inter','Segoe UI',system-ui,-apple-system,BlinkMacSystemFont,sans-serif;
   --font-display:'Space Grotesk','Manrope','Inter',system-ui,sans-serif;
+  --header-height:92px;
 }
 
 *{box-sizing:border-box}
@@ -30,6 +31,7 @@ body{
   line-height:1.7;
   letter-spacing:0.01em;
   min-height:100vh;
+  overflow-x:hidden;
 }
 body::before{
   content:"";
@@ -296,13 +298,36 @@ main{flex:1 0 auto}
   position:relative;
   transition:background .2s ease,border .2s ease;
 }
-.nav-toggle .nav-toggle-bar,.nav-toggle::before,.nav-toggle::after{content:"";display:block;width:20px;height:2px;background:var(--ink);border-radius:999px;transition:transform .2s ease,opacity .2s ease}
-.nav-toggle::before{position:absolute;margin-top:-7px}
-.nav-toggle::after{position:absolute;margin-top:7px}
+.nav-toggle .nav-toggle-bar,
+.nav-toggle::before,
+.nav-toggle::after{
+  content:"";
+  display:block;
+  width:20px;
+  height:2px;
+  background:var(--ink);
+  border-radius:999px;
+  transition:transform .2s ease, opacity .2s ease, top .2s ease;
+}
+.nav-toggle .nav-toggle-bar{position:relative}
+.nav-toggle::before,
+.nav-toggle::after{
+  position:absolute;
+  left:50%;
+  transform:translateX(-50%);
+  transform-origin:center;
+}
+.nav-toggle::before{top:calc(50% - 7px)}
+.nav-toggle::after{top:calc(50% + 7px)}
 .nav-toggle[aria-expanded="true"] .nav-toggle-bar{opacity:0}
-.nav-toggle[aria-expanded="true"]::before{transform:translateY(7px) rotate(45deg)}
-.nav-toggle[aria-expanded="true"]::after{transform:translateY(-7px) rotate(-45deg)}
-body.nav-open{overflow:hidden}
+.nav-toggle[aria-expanded="true"]::before,
+.nav-toggle[aria-expanded="true"]::after{top:50%}
+.nav-toggle[aria-expanded="true"]::before{transform:translate(-50%, -50%) rotate(45deg)}
+.nav-toggle[aria-expanded="true"]::after{transform:translate(-50%, -50%) rotate(-45deg)}
+body.nav-open{
+  overflow:hidden;
+  padding-right:var(--scrollbar-compensation, 0px);
+}
 label{display:block;font-weight:600;font-size:13px;letter-spacing:0.12em;text-transform:uppercase;color:var(--ink-subtle);margin-bottom:8px}
 .input,textarea{
   width:100%;
@@ -319,6 +344,11 @@ label{display:block;font-weight:600;font-size:13px;letter-spacing:0.12em;text-tr
 textarea{resize:vertical;min-height:160px}
 .form-row{display:flex;flex-wrap:wrap;gap:16px}
 .form-row > *{flex:1 1 220px}
+.form-status{margin-top:18px;font-size:14px;line-height:1.6;color:var(--ink-muted);display:none}
+.form-status.is-visible{display:block}
+.form-status--pending{color:var(--ink-subtle)}
+.form-status--success{color:var(--accent)}
+.form-status--error{color:rgba(255,142,164,0.92)}
 .footer .panel{background:linear-gradient(140deg, rgba(15,23,44,0.9), rgba(10,15,27,0.9))}
 .spotlight{position:relative;z-index:0;--mx:50%;--my:50%}
 .spotlight::before{
@@ -361,34 +391,143 @@ main.spotlight::before{inset:-220px -180px;opacity:0.5}
   .nav-toggle{display:flex}
   .nav{
     position:fixed;
-    inset:90px 24px auto 24px;
+    top:calc(var(--header-height, 92px) + 12px + env(safe-area-inset-top, 0px));
+    left:calc(env(safe-area-inset-left, 0px) + 20px);
+    right:calc(env(safe-area-inset-right, 0px) + 20px);
+    z-index:120;
     border-radius:24px;
-    padding:28px;
+    padding:24px;
     background:rgba(5,10,23,0.96);
     border:1px solid rgba(255,255,255,0.08);
     box-shadow:0 30px 70px rgba(3,6,16,0.7);
     flex-direction:column;
     align-items:flex-start;
     gap:12px;
+    max-width:420px;
+    margin:0 auto;
+    max-height:calc(100vh - (var(--header-height, 92px) + 36px + env(safe-area-inset-top, 0px) + env(safe-area-inset-bottom, 0px)));
+    overflow:auto;
+    overscroll-behavior:contain;
     transform:translateY(-20px);
     opacity:0;
     pointer-events:none;
     transition:opacity .25s ease, transform .25s ease;
+    padding-bottom:calc(24px + env(safe-area-inset-bottom, 0px));
   }
+  .nav a{width:100%;font-size:16px}
   .nav.is-open{opacity:1;transform:translateY(0);pointer-events:auto}
   .footer .footer-grid{grid-template-columns:1fr}
 }
 @media (max-width:720px){
   .container{width:min(100%,calc(100% - 32px))}
+  .header-row{gap:22px}
   .hero{padding:110px 0 80px}
+  .hero::after{inset:26px -60px -44px -60px}
   .hero h1{font-size:clamp(38px,9vw,52px)}
+  .hero .lead{font-size:17px}
   .hero-metrics{gap:24px}
   .section{padding:90px 0}
   .section-title{font-size:30px}
+  .section-lead{font-size:16px}
+  .grid{gap:22px}
+  .panel,.card,.timeline-step,.hero-panel{padding:28px}
   .cta{padding:48px 28px}
+  .cta p{font-size:16px}
+  .spotlight::before{inset:-150px -120px}
+  main.spotlight::before{inset:-190px -140px}
+}
+@media (max-width:600px){
+  .header-row{gap:18px}
+  .brand .logo{width:50px;height:50px}
+  .brand .wordmark{font-size:24px}
+  .hero{padding:104px 0 76px}
+  .hero .lead{font-size:16px}
+  .hero-metrics{gap:20px}
+  .hero-metrics li{min-width:150px}
+  .section{padding:84px 0}
+  .grid{gap:20px}
+  .panel,.card,.timeline-step,.hero-panel{padding:26px}
+  .cta{padding:44px 26px}
 }
 @media (max-width:520px){
-  .hero-panel{padding:28px}
-  .card{padding:28px}
-  .timeline-step{padding:24px}
+  .container{width:min(100%,calc(100% - 28px))}
+  .header-row{gap:16px}
+  .nav{left:calc(env(safe-area-inset-left, 0px) + 16px);right:calc(env(safe-area-inset-right, 0px) + 16px);padding:22px;padding-bottom:calc(22px + env(safe-area-inset-bottom, 0px))}
+  .nav a{font-size:15px}
+  .nav-toggle{width:44px;height:44px}
+  .brand{gap:12px}
+  .brand .logo{width:46px;height:46px}
+  .brand .wordmark{font-size:22px;letter-spacing:0.06em}
+  .btn{padding:12px 16px;font-size:14px;border-radius:14px}
+  .hero{padding:100px 0 72px}
+  .hero::after{inset:20px -40px -36px -40px}
+  .hero h1{font-size:clamp(34px,10vw,48px)}
+  .hero .lead{font-size:16px}
+  .hero-cta{gap:10px}
+  .hero-cta .btn{width:100%}
+  .hero-metrics{gap:18px}
+  .hero-metrics li{min-width:140px}
+  .section{padding:80px 0}
+  .section-title{font-size:clamp(26px,8vw,30px)}
+  .section-lead{font-size:15px}
+  .grid{gap:20px}
+  .hero-panel,.card,.timeline-step,.panel{padding:24px;border-radius:22px}
+  .cta{padding:40px 24px;border-radius:30px}
+  .cta h2{font-size:clamp(26px,8vw,32px)}
+  .cta p{font-size:15px}
+  .spotlight::before{inset:-130px -100px}
+  main.spotlight::before{inset:-170px -120px}
+  .footer{padding:60px 0 40px}
+  .footer-title{font-size:24px}
+  .footer .footer-grid{gap:32px}
+  .footer .footer-meta{gap:18px;font-size:12px}
+  .quote{font-size:17px}
+}
+@media (max-width:420px){
+  .container{width:min(100%,calc(100% - 24px))}
+  .header-row{gap:14px}
+  .brand{gap:10px}
+  .brand .logo{width:44px;height:44px}
+  .brand .wordmark{font-size:20px}
+  .nav{left:calc(env(safe-area-inset-left, 0px) + 12px);right:calc(env(safe-area-inset-right, 0px) + 12px);padding:20px 18px;padding-bottom:calc(20px + env(safe-area-inset-bottom, 0px))}
+  .nav-toggle{width:42px;height:42px}
+  .nav a{font-size:15px;padding:12px 16px}
+  .hero{padding:92px 0 64px}
+  .hero::after{inset:16px -28px -30px -28px}
+  .hero h1{font-size:clamp(32px,10vw,44px)}
+  .hero .lead{font-size:15px}
+  .hero-cta{gap:8px;flex-direction:column;align-items:stretch}
+  .hero-cta .btn{width:100%}
+  .hero-metrics{gap:16px}
+  .hero-metrics li{min-width:0}
+  .section{padding:72px 0}
+  .section-title{font-size:clamp(24px,9vw,30px)}
+  .section-lead{font-size:15px}
+  .grid{gap:18px}
+  .hero-panel,.card,.timeline-step,.panel{padding:22px;border-radius:20px}
+  .cta{padding:32px 20px;border-radius:26px}
+  .cta h2{font-size:clamp(24px,9vw,30px)}
+  .cta p{font-size:15px}
+  .spotlight::before{inset:-120px -90px}
+  main.spotlight::before{inset:-150px -110px}
+  .footer{padding:56px 0 36px}
+  .footer .footer-grid{gap:28px}
+  .footer .footer-meta{flex-direction:column;align-items:flex-start;gap:14px}
+  .footer-title{font-size:22px}
+  .quote{font-size:16px}
+}
+@media (max-width:360px){
+  .container{width:min(100%,calc(100% - 20px))}
+  .brand .wordmark{font-size:18px;letter-spacing:0.05em}
+  .hero{padding:88px 0 60px}
+  .hero::after{inset:12px -20px -26px -20px}
+  .hero h1{font-size:clamp(30px,11vw,38px)}
+  .hero .lead{font-size:14px}
+  .hero-cta{gap:6px}
+  .btn{padding:10px 14px}
+  .nav{padding:18px;padding-bottom:calc(18px + env(safe-area-inset-bottom, 0px))}
+  .nav a{padding:10px 12px}
+  .section{padding:68px 0}
+  .cta{padding:28px 18px}
+  .footer{padding:52px 0 32px}
 }

--- a/contact.html
+++ b/contact.html
@@ -61,23 +61,24 @@
           </div>
           <div class="panel">
             <h3>Send a message</h3>
-            <form id="contactForm">
+            <form id="contactForm" data-endpoint="/api/contact">
               <div class="form-row">
                 <div>
                   <label for="yourName">Your name</label>
-                  <input class="input" type="text" id="yourName" placeholder="Name or organization" required>
+                  <input class="input" type="text" id="yourName" name="name" placeholder="Name or organization" autocomplete="name" required>
                 </div>
                 <div>
                   <label for="yourEmail">Email</label>
-                  <input class="input" type="email" id="yourEmail" placeholder="you@example.com" required>
+                  <input class="input" type="email" id="yourEmail" name="email" placeholder="you@example.com" autocomplete="email" required>
                 </div>
               </div>
               <label for="yourMessage" class="mt-16">Message</label>
-              <textarea id="yourMessage" rows="6" placeholder="Tell us about your protocol needs"></textarea>
+              <textarea id="yourMessage" name="message" rows="6" placeholder="Tell us about your protocol needs" minlength="10" required></textarea>
               <div class="hero-cta mt-24">
-                <button class="btn primary" type="submit">Open email draft</button>
-                <a class="btn ghost" href="mailto:axadmihn@axnmihn.com">Send directly</a>
+                <button class="btn primary" type="submit">Send message</button>
+                <a class="btn ghost" href="mailto:axadmihn@axnmihn.com" data-direct-email>Send directly</a>
               </div>
+              <div class="form-status" id="contactStatus" role="status" aria-live="polite" aria-atomic="true"></div>
             </form>
           </div>
         </div>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "axnmihn-site",
+  "version": "1.0.0",
+  "description": "Axnmihn static site with contact email server",
+  "type": "module",
+  "scripts": {
+    "start": "node server/index.js",
+    "dev": "node server/index.js"
+  },
+  "dependencies": {
+    "dotenv": "^16.4.5",
+    "express": "^4.18.2",
+    "nodemailer": "^6.9.13"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,153 @@
+import express from 'express';
+import nodemailer from 'nodemailer';
+import dotenv from 'dotenv';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+dotenv.config();
+
+const app = express();
+const PORT = Number(process.env.PORT || 3000);
+const corsOrigin = process.env.CORS_ORIGIN || '';
+
+app.use(express.json({ limit: '1mb' }));
+app.use(express.urlencoded({ extended: false }));
+
+if (corsOrigin) {
+  app.use((req, res, next) => {
+    res.setHeader('Access-Control-Allow-Origin', corsOrigin);
+    res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+    if (req.method === 'OPTIONS') {
+      res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
+      return res.sendStatus(204);
+    }
+    return next();
+  });
+}
+
+app.options('/api/contact', (req, res) => {
+  if (corsOrigin) {
+    res.setHeader('Access-Control-Allow-Origin', corsOrigin);
+    res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+    res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
+  }
+  res.sendStatus(204);
+});
+
+const smtpHost = process.env.SMTP_HOST || '';
+const smtpPort = Number(process.env.SMTP_PORT || 587);
+const smtpSecure = String(process.env.SMTP_SECURE || '').toLowerCase() === 'true' || smtpPort === 465;
+const smtpUser = process.env.SMTP_USER || '';
+const smtpPass = process.env.SMTP_PASS || '';
+
+const transportOptions = smtpHost
+  ? {
+      host: smtpHost,
+      port: smtpPort,
+      secure: smtpSecure,
+      auth: smtpUser && smtpPass ? { user: smtpUser, pass: smtpPass } : undefined
+    }
+  : {
+      streamTransport: true,
+      newline: 'unix',
+      buffer: true
+    };
+
+const transporter = nodemailer.createTransport(transportOptions);
+const usingStreamTransport = Boolean(transportOptions.streamTransport);
+
+if (!usingStreamTransport) {
+  transporter
+    .verify()
+    .then(() => {
+      console.log('SMTP transport verified. Ready to send.');
+    })
+    .catch((error) => {
+      console.error('SMTP transport verification failed:', error.message);
+    });
+} else {
+  console.log('No SMTP credentials detected. Using development stream transport (emails logged to console).');
+}
+
+const escapeHtml = (value = '') =>
+  String(value).replace(/[&<>"']/g, (char) => ({
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#39;'
+  })[char] || char);
+
+const trimAndClean = (value) => String(value || '').trim().replace(/\r\n?/g, '\n');
+
+app.post('/api/contact', async (req, res) => {
+  if (corsOrigin) {
+    res.setHeader('Access-Control-Allow-Origin', corsOrigin);
+  }
+
+  const name = trimAndClean(req.body?.name);
+  const email = trimAndClean(req.body?.email);
+  const message = trimAndClean(req.body?.message);
+
+  if (!name || !email || !message) {
+    return res.status(400).json({ error: 'Missing required fields. Provide name, email, and message.' });
+  }
+
+  if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+    return res.status(400).json({ error: 'Please supply a valid email address.' });
+  }
+
+  if (message.length < 10) {
+    return res.status(400).json({ error: 'Tell us a bit more—messages must be at least 10 characters long.' });
+  }
+
+  if (message.length > 5000) {
+    return res.status(400).json({ error: 'Messages are limited to 5000 characters.' });
+  }
+
+  const toAddress = process.env.CONTACT_TO || smtpUser || 'axadmihn@axnmihn.com';
+  const fromAddress = process.env.CONTACT_FROM || `no-reply@${(process.env.DOMAIN || 'axnmihn.com').replace(/^https?:\/\//, '')}`;
+  const requesterIp = trimAndClean((req.headers['x-forwarded-for'] || req.socket.remoteAddress || '').toString().split(',')[0]);
+
+  const plainText = `${message}\n\nSender: ${name}\nEmail: ${email}${requesterIp ? `\nIP: ${requesterIp}` : ''}`;
+  const htmlBody = `<p>${escapeHtml(message).replace(/\n/g, '<br>')}</p><hr><p><strong>Sender:</strong> ${escapeHtml(
+    name
+  )}<br><strong>Email:</strong> <a href="mailto:${escapeHtml(email)}">${escapeHtml(email)}</a>${
+    requesterIp ? `<br><strong>IP:</strong> ${escapeHtml(requesterIp)}` : ''
+  }</p>`;
+
+  try {
+    const info = await transporter.sendMail({
+      to: toAddress,
+      from: fromAddress,
+      subject: `New Axnmihn contact from ${name}`,
+      replyTo: email,
+      text: plainText,
+      html: htmlBody
+    });
+
+    if (usingStreamTransport && info && info.message) {
+      console.log('Contact message preview:\n' + info.message.toString());
+    } else {
+      console.log('Contact message sent:', info.messageId || 'no-message-id');
+    }
+
+    return res.status(200).json({ ok: true });
+  } catch (error) {
+    console.error('Unable to send contact email:', error);
+    return res.status(500).json({ error: 'Internal error while sending email. Please try again later.' });
+  }
+});
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const staticDir = process.env.STATIC_DIR || path.resolve(__dirname, '..');
+
+app.use(express.static(staticDir, { extensions: ['html'] }));
+
+app.listen(PORT, () => {
+  console.log(`Server ready on http://localhost:${PORT}`);
+  if (corsOrigin) {
+    console.log(`CORS enabled for origin: ${corsOrigin}`);
+  }
+});


### PR DESCRIPTION
## Summary
- add scroll lock compensation so opening the mobile navigation no longer shifts the page width
- center and animate the navigation toggle icon while ensuring the overlay renders above the header
- restore safe-area padding for narrow mobile breakpoints and surface form status styles
- replace the mailto-only contact form with an API-backed submission flow plus a lightweight Node email service

## Testing
- node --check server/index.js

------
https://chatgpt.com/codex/tasks/task_e_68cf49da04808321992d83553a729d7f